### PR TITLE
add cv

### DIFF
--- a/cv.html
+++ b/cv.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+<head>
+	<title>CV Martim Lobao</title>
+	<link rel="canonical" href="https://www.dropbox.com/scl/fi/uyulbpi1o6vd1krlc0miv/CV-Martim-Lobao.pdf?rlkey=8i72l3c0ititt7uwft3evtou8&dl=0" />
+	<meta charset="utf-8" />
+	<meta http-equiv="refresh" content="0; url=https://www.dropbox.com/scl/fi/uyulbpi1o6vd1krlc0miv/CV-Martim-Lobao.pdf?rlkey=8i72l3c0ititt7uwft3evtou8&dl=0" />
+</head>
+<body>
+	<p>CV Martim Lobao</p>
+</body>
+</html>

--- a/resume.html
+++ b/resume.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+<head>
+	<title>Resume Martim Lobao</title>
+	<link rel="canonical" href="https://www.dropbox.com/scl/fi/uyulbpi1o6vd1krlc0miv/CV-Martim-Lobao.pdf?rlkey=8i72l3c0ititt7uwft3evtou8&dl=0" />
+	<meta charset="utf-8" />
+	<meta http-equiv="refresh" content="0; url=https://www.dropbox.com/scl/fi/uyulbpi1o6vd1krlc0miv/CV-Martim-Lobao.pdf?rlkey=8i72l3c0ititt7uwft3evtou8&dl=0" />
+</head>
+<body>
+	<p>Resume Martim Lobao</p>
+</body>
+</html>


### PR DESCRIPTION
- under /cv and /resume

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Introduce new HTML pages for CV and Resume that redirect users to an external PDF document.

New Features:
- Add a CV page at /cv that redirects to an external PDF link.
- Add a Resume page at /resume that redirects to the same external PDF link as the CV page.

<!-- Generated by sourcery-ai[bot]: end summary -->