### PR TITLE
Revert "feat: Add Bluesky verification"

### DIFF
--- a/.well-known/atproto-did
+++ b/.well-known/atproto-did
@@ -1,1 +1,0 @@
-did:plc:ewvhhpj4o6obv7txyinxg6um


### PR DESCRIPTION
Reverts martimlobao/martimlobao.com#7

## Summary by Sourcery

Chores:
- Remove the atproto-did file as part of reverting the Bluesky verification feature.